### PR TITLE
(#18) Added pip requirements.txt

### DIFF
--- a/src/game/requirements.txt
+++ b/src/game/requirements.txt
@@ -1,0 +1,3 @@
+colorama==0.4.3
+pyfiglet==0.8.post1
+pyserial==3.4


### PR DESCRIPTION
Added a requirements.txt (using `pip freeze > requirements.txt`) to the `src/game` folder. This allows easy setup/dependency grabbing for new machines. Fixes #18.